### PR TITLE
Updates platform version and improves provider logic

### DIFF
--- a/MAIN/.vscode/launch.json
+++ b/MAIN/.vscode/launch.json
@@ -22,7 +22,7 @@
             "request": "launch",
             "name": "Local Container",
             "environmentType": "OnPrem",
-            "server": "http://bccomm22",
+            "server": "http://bc27nz",
             "serverInstance": "BC",
             "authentication": "UserPassword",
             "breakOnError": true,

--- a/MAIN/app.json
+++ b/MAIN/app.json
@@ -2,20 +2,23 @@
   "id": "c42f2379-d7b5-4378-8ce4-9bca293c6189",
   "name": "OpenFeature",
   "publisher": "Theta Systems Limited",
-  "version": "3.4.0.1",
+  "version": "4.0.0.0",
   "brief": "Feature Flagging / Toggling / Switching",
   "description": "Same as a brief one",
   "privacyStatement": "https://www.theta.co.nz/privacy-policy",
   "EULA": "https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE5d5ga",
-  "help": "https://www.theta.co.nz/contact-us",
+  "help": "http://featureflags.io/feature-flags/",
   "url": "https://www.theta.co.nz/",
   "logo": "../logo.png",
   "propagateDependencies": true,
   "dependencies": [],
+  "suppressWarnings": [
+    "AA0247"
+  ],
   "screenshots": [],
   "target": "Cloud",
-  "platform": "22.0.0.0",
-  "application": "22.0.0.0",
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
   "idRanges": [
     {
       "from": 70254345,
@@ -23,13 +26,18 @@
     }
   ],
   "contextSensitiveHelpUrl": "http://featureflags.io/feature-flags/",
-  "supportedLocales": ["en-NZ", "en-AU", "en-US", "en-GB"],
+  "supportedLocales": [
+    "en-NZ",
+    "en-AU",
+    "en-US",
+    "en-GB"
+  ],
   "resourceExposurePolicy": {
     "allowDebugging": true,
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "runtime": "11.0",
+  "runtime": "16.0",
   "features": [
     "TranslationFile",
     "NoImplicitWith",

--- a/MAIN/src/FeatureConditions/ValidFeatures.Query.al
+++ b/MAIN/src/FeatureConditions/ValidFeatures.Query.al
@@ -14,14 +14,14 @@ query 70254346 "ValidFeatures_FF_TSL"
             {
 
             }
-            filter(ConditionCodeFilter; ConditionCodeFilter)
-            {
-
-            }
             dataitem(FeatureCondition2; FeatureCondition_FF_TSL)
             {
-                DataItemLink = FeatureID = FeatureCondition.FeatureID, ConditionCode = FeatureCondition.ConditionCodeFilter;
+                DataItemLink = FeatureID = FeatureCondition.FeatureID;
                 SqlJoinType = LeftOuterJoin;
+                filter(ConditionCodeFilter; ConditionCode)
+                {
+
+                }
                 column(Count)
                 {
                     Method = Count;

--- a/MAIN/src/Features/FeatureMgt.Codeunit.al
+++ b/MAIN/src/Features/FeatureMgt.Codeunit.al
@@ -355,9 +355,11 @@ codeunit 70254347 "FeatureMgt_FF_TSL"
                 if Provider.CaptureEvents().Get(Format(FeatureEvent), CaptureEventJsonToken) then begin
                     CustomDimensions.Add('FeatureID', FeatureID);
                     IProvider := Provider.Type;
+#pragma warning disable AA0005
                     if CaptureEventJsonToken.AsValue().AsBoolean() then begin
                         // TODO: Capture event in background
                     end else
+#pragma warning restore AA0005
                         TryCaptureEvent(IProvider, Provider.ConnectionInfo(), EventDateTime, FeatureEvent, CustomDimensions);
                 end
             end

--- a/MAIN/src/Providers/PostHogProvider.Codeunit.al
+++ b/MAIN/src/Providers/PostHogProvider.Codeunit.al
@@ -117,7 +117,7 @@ codeunit 70254353 "PostHogProvider_FF_TSL" implements IProvider_FF_TSL
                     FeatureMgt.GetValue(FeatureJsonToken.AsObject(), 'name')
                 )
     end;
-
+#pragma warning disable AA0228
     [NonDebuggable]
     local procedure CreateIdentity(User: Record User; ConnectionInfo: JsonObject): Boolean
     var
@@ -129,6 +129,7 @@ codeunit 70254353 "PostHogProvider_FF_TSL" implements IProvider_FF_TSL
         Content.Add('$set', ContextAttributes);
         exit(Capture(PostHogEvent_FF_TSL::Identify, CurrentDateTime(), Content, ConnectionInfo))
     end;
+#pragma warning restore AA0228
 
     [NonDebuggable]
     local procedure FeatureFlagCalled(EventDateTime: DateTime; CustomDimensions: Dictionary of [Text, Text]; Enabled: Boolean; ConnectionInfo: JsonObject): Boolean


### PR DESCRIPTION
Upgrades app, platform, and runtime versions to 4.0.0.0 and 27.0.0.0, enabling compatibility with newer environments. Adjusts feature query logic and suppresses warning AA0247. Adds pragmas to control code analysis warnings in provider logic for improved code quality and maintainability.